### PR TITLE
fix blend color

### DIFF
--- a/android/alpha_player/src/main/java/com/ss/ugc/android/alpha_player/render/VideoRenderer.kt
+++ b/android/alpha_player/src/main/java/com/ss/ugc/android/alpha_player/render/VideoRenderer.kt
@@ -115,7 +115,7 @@ class VideoRenderer(val alphaVideoView: IAlphaVideoView) : IRender {
             return
         }
         GLES20.glEnable(GLES20.GL_BLEND)
-        GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA)
+        GLES20.glBlendFunc(GLES20.GL_ONE, GLES20.GL_ONE_MINUS_SRC_ALPHA)
 
         GLES20.glUseProgram(programID)
         checkGlError("glUseProgram")


### PR DESCRIPTION
The color of your left video is (A, A, A,1.0), and the color of your right video is (R * A, G *A, B * A,1.0).
The mix colors in shader are (R* A, G *A, B *A,A).
So shader color is actually pre-multiplied.

And then use it in the VideoRenderer
GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA,GLES20.GL_ONE_MINUS_SRC_ALPHA)
Merged (0,0,0,0)
In fact, the final color is (R *A* A, G *A*A, B * A *A, A * A).
This is wrong, blend two  pre-multiplied colors that must be used
GLES20.glBlendFunc(GLES20. GL_ONE, GLES20.GL_ONE_MINUS_SRC_ALPHA).

if left video is (A, A, A,1.0), and right video is (R , G , B ,1.0),in shader must Multiplied A